### PR TITLE
Change google loader name to more verbose one

### DIFF
--- a/src/dyacon/loaders/external.py
+++ b/src/dyacon/loaders/external.py
@@ -46,7 +46,7 @@ def get_google_cloud_secret(
     return None
 
 
-GOOGLE_LOADER_PATTERN = re.compile(
+GOOGLE_CLOUD_SECRETS_LOADER_PATTERN = re.compile(
     r'!{'
     r'(?P<name>[^}^{:]+)'
     r'(?P<first_separator>:?)'
@@ -57,9 +57,9 @@ GOOGLE_LOADER_PATTERN = re.compile(
 )
 
 
-class GoogleLoader(Loader):
+class GoogleCloudSecretsLoader(Loader):
     def __init__(self) -> None:
-        self._pattern = GOOGLE_LOADER_PATTERN
+        self._pattern = GOOGLE_CLOUD_SECRETS_LOADER_PATTERN
 
     @property
     def pattern(self) -> Pattern[str]:
@@ -97,7 +97,7 @@ class GoogleLoader(Loader):
         return config_content
 
 
-class GoogleLoad(Load):
+class GoogleCloudSecretsLoad(Load):
     def __init__(self, loaders: Optional[List[Loader]] = None) -> None:
         super().__init__(loaders)
-        self.loaders.append(GoogleLoader())
+        self.loaders.append(GoogleCloudSecretsLoader())

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from dyacon import Load
-from dyacon.loaders.external import GoogleLoad, SecretManagerServiceClient
+from dyacon.loaders.external import GoogleCloudSecretsLoad, SecretManagerServiceClient
 from dyacon.read import dataclass_from_dict
 
 
@@ -67,7 +67,7 @@ def test_env_loader_several_groups():
 def test_google_loader_default():
     @dataclass
     class Config:
-        key1: str = GoogleLoad()
+        key1: str = GoogleCloudSecretsLoad()
 
     config_dict = {'key1': '!{secret_name:project_id:default}'}
 
@@ -84,7 +84,7 @@ def test_google_loader_default():
 def test_google_loader_without_default():
     @dataclass
     class Config:
-        key1: str = GoogleLoad()
+        key1: str = GoogleCloudSecretsLoad()
 
     config_dict = {'key1': '!{secret_name:project_id}'}
 


### PR DESCRIPTION
Optional, but I think it is better to specify a value source a bit more accurately. 
Google has a lot of services already and I belive it might launch something with the similar functionality in the future.
The change is breaking, however considering 0.0.x version it should be expected.